### PR TITLE
orders clusters by CLI and adds docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Crossed-out listings indicate deprecated packages.
   - ~~Flask~~
   - Pandas
   - Textstat
+  - scikit-learn
 - Google Cloud Vision services
 
 ### 2️⃣ Predictions

--- a/dotPy/matchmaking.py
+++ b/dotPy/matchmaking.py
@@ -85,7 +85,8 @@ def break_clusters(df):
     
     for i in range(no_cluster):
         cluster_df = df[df['cluster'] == i]
-        cluster_index = cluster_df.sort_values('coleman_liau_index').index
+        # cluster_index = cluster_df.sort_values('coleman_liau_index').index
+        cluster_index = cluster_df.index
         matches.update(break_index(list(cluster_index), len(matches)))
         
     return str(matches)


### PR DESCRIPTION
# Description

Orders clusters by CLI before breaking into matches. Also adds docstrings for new functions.

Fixes # (issue)

Random in-cluster ordering of matches, could result in lower-quality matches within larger clusters.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Change Status

- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] Locally

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
